### PR TITLE
build on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ ifeq ($(OS),SunOS)
 CFLAGS += -m32
 CFLAGS += -lnsl -lsocket
 endif
+ifeq ($(OS),Linux)
+CFLAGS += -lpthread
+endif
 
 PROG = sercons
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 OS := $(shell uname)
 
-CFLAGS = -Wall -Wextra -Werror
+CFLAGS = -Wall -Wextra -Werror -lpthread
 ifeq ($(OS),Darwin)
 CFLAGS += -m32
 CFLAGS += -mmacosx-version-min=10.6
@@ -9,9 +9,6 @@ endif
 ifeq ($(OS),SunOS)
 CFLAGS += -m32
 CFLAGS += -lnsl -lsocket
-endif
-ifeq ($(OS),Linux)
-CFLAGS += -lpthread
 endif
 
 PROG = sercons

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ OS := $(shell uname)
 
 CFLAGS = -Wall -Wextra -Werror -lpthread
 ifeq ($(OS),Darwin)
-CFLAGS += -m32
 CFLAGS += -mmacosx-version-min=10.6
 endif
 ifeq ($(OS),SunOS)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 OS := $(shell uname)
 
-CFLAGS = -Wall -Wextra -Werror -lpthread
+CFLAGS = -Wall -Wextra -Werror -pthread
 ifeq ($(OS),Darwin)
 CFLAGS += -mmacosx-version-min=10.6
 endif


### PR DESCRIPTION
This small change allows it to build on Fedora 30.  I did not include `-m32` because that required header files I didn't already have installed and there seems to be no clear reason to force a 32-bit build.